### PR TITLE
Ignore BUILDKITE_PULL_REQUEST in "prepare_to_publish_to_s3_params" if it's set to false

### DIFF
--- a/scripts/prepare_to_publish_to_s3_params
+++ b/scripts/prepare_to_publish_to_s3_params
@@ -3,5 +3,5 @@
 PARAMS=(--sha1=$BUILDKITE_COMMIT)
 [[ -n "$BUILDKITE_TAG" ]] && PARAMS+=(--tag-name=$BUILDKITE_TAG)
 [[ -n "$BUILDKITE_BRANCH" ]] && PARAMS+=(--branch-name=$BUILDKITE_BRANCH)
-[[ -n "$BUILDKITE_PULL_REQUEST" ]] && PARAMS+=(--pull-request-number=$BUILDKITE_PULL_REQUEST)
+[[ -n "$BUILDKITE_PULL_REQUEST" && "$BUILDKITE_PULL_REQUEST" != "false" ]] && PARAMS+=(--pull-request-number=$BUILDKITE_PULL_REQUEST)
 echo "${PARAMS[@]}"


### PR DESCRIPTION
Buildkite sets `BUILDKITE_PULL_REQUEST` to `false` instead of leaving it empty when there is no pull request open for a job. This PR improves the check for this in `prepare_to_publish_to_s3_params` script so we don't end up with version numbers such as `false-{sha1}`. 😞 

**To test:**
* `export BUILDKITE_PULL_REQUEST="false"`
* Run `./scripts/prepare_to_publish_to_s3_params` in `trunk` and observe that it prints out `--sha1= --pull-request-number=false`
* Run `./scripts/prepare_to_publish_to_s3_params` in this branch and observe that it prints out `--sha1=`