### PR TITLE
Cache Gradle 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,14 @@ RUN yes | sdkmanager --licenses
 RUN mkdir scripts
 COPY scripts/ scripts/
 ENV PATH="/scripts/:${PATH}"
+
+# Cache Gradle 7.4
+RUN mkdir gradle-cache-tmp \
+        && cd gradle-cache-tmp \
+        && wget https://services.gradle.org/distributions/gradle-7.4-bin.zip \
+        && unzip gradle-7.4-bin.zip \
+        && touch settings.gradle \
+        && gradle-7.4/bin/gradle wrapper --gradle-version 7.4 --distribution-type all \
+        && ./gradlew \
+        && cd .. \
+        && rm -rf ./gradle-cache-tmp \


### PR DESCRIPTION
This PR caches Gradle `7.4` in the Docker image. It didn't end up being necessary for the Tumblr work I've been doing, but I think it'd useful for our other projects since @ParaskP7 is upgrading them to `7.4`.

Once this PR is merged, we can create `v1.2.0` tag and start using that instead of `v1.1.0` with the only difference between the two images being the cached Gradle `7.4`.