### PR TITLE
Update JDK version to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,17 @@ RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6858069
 
 ENV PATH="//usr/lib/android-sdk/cmdline-tools/latest/bin:${PATH}"
 
-RUN sdkmanager "platforms;android-30" "system-images;android-30;google_apis_playstore;x86_64" "build-tools;30.0.0"
-
 RUN yes | sdkmanager --licenses
+
+# Uninstall '29.0.3' so that the builds won't complain about it being installed in incorrect location
+RUN sdkmanager --uninstall "build-tools;29.0.3"
+
+RUN sdkmanager --install \
+  "build-tools;33.0.2" \
+  "build-tools;34.0.0" \
+  "platform-tools" \
+  "platforms;android-33" \
+  "platforms;android-34"
 
 RUN mkdir scripts
 COPY scripts/ scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ RUN mkdir scripts
 COPY scripts/ scripts/
 ENV PATH="/scripts/:${PATH}"
 
-# Cache Gradle 7.4
+# Cache Gradle 8.2.1
 RUN mkdir gradle-cache-tmp \
         && cd gradle-cache-tmp \
-        && wget https://services.gradle.org/distributions/gradle-7.4-bin.zip \
-        && unzip gradle-7.4-bin.zip \
+        && wget https://services.gradle.org/distributions/gradle-8.2.1-bin.zip \
+        && unzip gradle-8.2.1-bin.zip \
         && touch settings.gradle \
-        && gradle-7.4/bin/gradle wrapper --gradle-version 7.4 --distribution-type all \
+        && gradle-8.2.1/bin/gradle wrapper --gradle-version 8.2.1 --distribution-type all \
         && ./gradlew \
         && cd .. \
         && rm -rf ./gradle-cache-tmp \


### PR DESCRIPTION
This PR adds support for JDK 17 by rebuilding the image. There was no extra action needed for this as I think it's covered by one of the `apt-get` packages. Note that this removes support for JDK 11, but since this Docker image is only used for `gutenberg-mobile`, we shouldn't need it. I believe our long term plan is to deprecate this image entirely, so I don't think it's worth spending the extra time to support multiple JDK versions.

I've updated the Android build tools to `33` (current) & `34` (upcoming) and uninstalled `29` so that builds won't complain about it being installed in an incorrect location which I think is related to the `apt-get` package installations. I've also updated the cached Gradle version to `8.2.1`.

**To Test**

I've updated `gutenberg-mobile` to use this image in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5993 and verified that the CI is green. Prior to this change, the builds were failing due to the missing JDK 17 in https://github.com/wordpress-mobile/gutenberg-mobile/pull/5989. So, no testing is necessary.