### PR TITLE
Node with JDK17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,10 @@ COPY scripts/ scripts/
 ENV PATH="/scripts/:${PATH}"
 
 SHELL ["/bin/bash", "--login", "-c"]
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-RUN export NVM_DIR="$HOME/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && nvm install lts/*
+ENV NODE_VERSION v20.11.0
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+    && source "$HOME/.nvm/nvm.sh" \
+    && nvm install $NODE_VERSION
+ENV PATH="//root/.nvm/versions/node/$NODE_VERSION/bin:${PATH}"
+
+RUN which npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM debian:stable
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
+# Increase the file watcher limit for node. This should not be necessary for CI builds since watchers should be disabled, but it can be useful when running this image in a local environment. 
+RUN echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf
+
 # Install system commands, Android SDK, and Ruby
 RUN apt-get update  \
     && apt-get install -y coreutils git wget locales android-sdk android-sdk-build-tools \
+    && apt-get install -y curl git php-cli php-mbstring  \
     && apt-get -y autoclean
 
 # Set up the default locale
@@ -47,4 +51,8 @@ RUN mkdir gradle-cache-tmp \
         && gradle-8.2.1/bin/gradle wrapper --gradle-version 8.2.1 --distribution-type all \
         && ./gradlew \
         && cd .. \
-        && rm -rf ./gradle-cache-tmp \
+        && rm -rf ./gradle-cache-tmp
+
+SHELL ["/bin/bash", "--login", "-c"]
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+RUN nvm install lts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ENV ANDROID_HOME=/usr/lib/android-sdk
 ENV GRADLE_OPTS="-Xmx6G -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.caching=true -Dorg.gradle.configureondemand=true -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false"
 
 # Download the SDK Manager
-RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip \
-	&& unzip commandlinetools-linux-6858069_latest.zip && rm commandlinetools-linux-6858069_latest.zip \
-	&& mkdir /usr/lib/android-sdk/cmdline-tools \
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+	&& unzip commandlinetools-linux-11076708_latest.zip && rm commandlinetools-linux-11076708_latest.zip \
+	&& mkdir -p /usr/lib/android-sdk/cmdline-tools \
 	&& mv cmdline-tools /usr/lib/android-sdk/cmdline-tools/latest
 
 ENV PATH="//usr/lib/android-sdk/cmdline-tools/latest/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf
 
 # Install system commands, Android SDK, and Ruby
 RUN apt-get update  \
-    && apt-get install -y coreutils git wget locales android-sdk android-sdk-build-tools \
+    && apt-get install -y coreutils git wget locales \
     && apt-get install -y curl git php-cli php-mbstring  \
     && apt-get -y autoclean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM debian:stable
+FROM gradle:8.2.1-jdk17
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
@@ -41,17 +41,6 @@ RUN sdkmanager --install \
 RUN mkdir scripts
 COPY scripts/ scripts/
 ENV PATH="/scripts/:${PATH}"
-
-# Cache Gradle 8.2.1
-RUN mkdir gradle-cache-tmp \
-        && cd gradle-cache-tmp \
-        && wget https://services.gradle.org/distributions/gradle-8.2.1-bin.zip \
-        && unzip gradle-8.2.1-bin.zip \
-        && touch settings.gradle \
-        && gradle-8.2.1/bin/gradle wrapper --gradle-version 8.2.1 --distribution-type all \
-        && ./gradlew \
-        && cd .. \
-        && rm -rf ./gradle-cache-tmp
 
 SHELL ["/bin/bash", "--login", "-c"]
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,6 @@ ENV PATH="/scripts/:${PATH}"
 
 SHELL ["/bin/bash", "--login", "-c"]
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-RUN nvm install lts/*
+RUN export NVM_DIR="$HOME/.nvm" \
+    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
+    && nvm install lts/*


### PR DESCRIPTION
## Description

This PR adds JDK 17, Gradle `8.2.1` and `npm` to the image. For more context about certain decisions, please see commit messages.

Used in: https://github.com/wordpress-mobile/react-native-libraries-publisher/pull/36

This is probably not gonna to be merged, similarly to #7 